### PR TITLE
fix: update awscc provider constraint to support post GA versions

### DIFF
--- a/provider.tf
+++ b/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     awscc = {
       source  = "hashicorp/awscc"
-      version = "~> 0.9"
+      version = ">= 1.0"
     }
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
# Description

Updating the provider constraint on the awscc provider to support later versions.